### PR TITLE
Update go.mod so it can be imported

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module eway-rapid-go
+module github.com/sashaskr/eway-rapid-go
 
 go 1.16
 


### PR DESCRIPTION
module name must match the import path
so for others to import your module, since
it is hosted at github.com/sashaskr/eway-rapid-go
that must be the module name